### PR TITLE
Fastai channel missing

### DIFF
--- a/molpmofit.yml
+++ b/molpmofit.yml
@@ -2,6 +2,7 @@ name: molpmofit
 channels:
   - conda-forge
   - defaults
+  - fastai
 dependencies:
   - rdkit
   - fastai


### PR DESCRIPTION
Missing **fastai** channel prevents successful conda environment creation.